### PR TITLE
[Client] 디베이트 페이지 (OnGoingDebate) - EditOrDeleteModal 

### DIFF
--- a/client/src/components/debate/OnGoingDebate.jsx
+++ b/client/src/components/debate/OnGoingDebate.jsx
@@ -1,10 +1,38 @@
 // import axios from "axios";
-
 import { StrawBtn } from "../btn/BaseBtn";
-
-// import axios from "axios";
+import EditOrDeleteModal from "../modal/EditOrDeleteModal";
+import { HiOutlineDotsVertical } from "react-icons/hi";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import { useState } from "react";
+import ConfirmModal from "../modal/ConfirmModal";
 
 export default function OnGoingDebate(debate) {
+  const [isModalOn, setIsModalOn] = useState(false);
+  const navigate = useNavigate();
+  //console.log(debate.debateInfo);
+
+  function toggleModal() {
+    setIsModalOn(!isModalOn);
+  }
+
+  //confirm모달 오픈
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const openModalHandler = () => {
+    setIsConfirmOpen(true);
+  };
+
+  function deleteDebate() {
+    axios
+      .delete(`${process.env.REACT_APP_API_URL}/debate/${debate.debateInfo.id}`)
+      .then((res) => {
+        console.log(res);
+        alert("delete success!");
+        navigate("/forum");
+      })
+      .catch((err) => err);
+  }
+
   return (
     <>
       <div className="bg-politics w-full h-410 bg-cover bg-center flex justify-center items-center">
@@ -13,17 +41,55 @@ export default function OnGoingDebate(debate) {
       {!debate.debateInfo.participant_id ? (
         debate.debateInfo.host_id === debate.debateInfo.pros_id ? (
           <div>
+            <HiOutlineDotsVertical onClick={toggleModal} />
+
+            {isModalOn ? (
+              <EditOrDeleteModal
+                editCallback={() => {
+                  navigate(`/forum/edit/${debate.debateInfo.id}`);
+                }}
+                deleteCallback={openModalHandler}
+              />
+            ) : null}
+            {isConfirmOpen ? (
+              <ConfirmModal
+                content={{ title: "Confirm", text: "Do you want to delete this debate?", left: "NO", right: "YES" }}
+                cancelCallback={() => {
+                  setIsConfirmOpen(false);
+                }}
+                confirmCallback={deleteDebate}
+              />
+            ) : null}
             <div>
               <div>pros</div>
               <img src={debate.prosProfile} className="w-140 h-140 object-cover rounded-full" />
             </div>
             <div>
-              <div>const</div>
+              <div>cons</div>
               <div className="bg-grayduck w-140 h-140 bg-cover rounded-full"></div>
             </div>
           </div>
         ) : (
           <div>
+            <HiOutlineDotsVertical onClick={toggleModal} />
+            {isModalOn ? (
+              <EditOrDeleteModal
+                editCallback={() => {
+                  navigate(`/forum/edit/${debate.debateInfo.id}`);
+                }}
+                deleteCallback={openModalHandler}
+              />
+            ) : null}
+            {isConfirmOpen ? (
+              <ConfirmModal
+                content={{ title: "Confirm", text: "Do you want to delete this debate?", left: "NO", right: "YES" }}
+                cancelCallback={() => {
+                  setIsConfirmOpen(false);
+                }}
+                confirmCallback={deleteDebate}
+              />
+            ) : null}
+
             <div>
               <div>pros</div>
               <div className="bg-grayduck w-140 h-140 bg-cover rounded-full"></div>


### PR DESCRIPTION
### 반영 브랜치
> feat/MyPage -> dev

### 변경 사항
> EditOrDeleteModal의 Edit과 Delete  기능
### 테스트 결과
> Edit 클릭시 해당 EditDebate페이지로 이동
   Delete 클릭시 debate 삭제

![스크린샷 2022-03-03 오전 3 19 24](https://user-images.githubusercontent.com/85834764/156423767-6960e7f0-94b3-4121-88b8-a256fe254cb9.png)

